### PR TITLE
Also target netstandard2.0

### DIFF
--- a/src/Wiry.Base32/Wiry.Base32.csproj
+++ b/src/Wiry.Base32/Wiry.Base32.csproj
@@ -1,7 +1,7 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard1.1;net45</TargetFrameworks>
+    <TargetFrameworks>netstandard1.1;netstandard2.0;net45</TargetFrameworks>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageId>Wiry.Base32</PackageId>
     <Version>1.1.1</Version>


### PR DESCRIPTION
Also target netstandard2.0 so we don't get the `NETStandard.Library >=1.6.1` dependency.